### PR TITLE
remount filesystem readonly before boot, add file checks for init

### DIFF
--- a/initrd/bin/resume
+++ b/initrd/bin/resume
@@ -45,6 +45,8 @@ boot() {
   # Copy MAC
   wait
   cp /mnt/config/mac_addr /mnt/root/etc
+  # remount rootfs readonly for filesystem check to work
+  mount -o remount,ro /mnt/root
   # kill running daemons
   kill -9 $(cat /run/dropbear.pid)
   kill -9 $(cat /run/udhcpc.pid)
@@ -58,7 +60,7 @@ boot() {
 }
 
 # Clean up and boot
-if [ -h /mnt/root/sbin/init ]; then
+if [ -h /mnt/root/sbin/init -o -e /mnt/root/sbin/init ]; then
   boot
 fi
 #check for LUKS-devices
@@ -68,7 +70,7 @@ if
 fi
 initlvm
 mount -o rw $(findfs LABEL=rootfs) /mnt/root
-if [ -h /mnt/root/sbin/init ]; then
+if [ -h /mnt/root/sbin/init -o -e /mnt/root/sbin/init ]; then
   boot
 else
   echo -e "Opps, boot failed"

--- a/initrd/init
+++ b/initrd/init
@@ -99,6 +99,8 @@ boot() {
   # Copy MAC
   wait
   cp /mnt/config/mac_addr /mnt/root/etc
+  # remount rootfs readonly for filesystem check to work
+  mount -o remount,ro /mnt/root
   # kill running daemons
   kill -9 $(cat /run/dropbear.pid) 2>&1 >/dev/null
   kill -9 $(cat /run/udhcpc.pid) 2>&1 >/dev/null


### PR DESCRIPTION
Hi Carl,

I added additional checks with "-e" for /sbin/init which are needed when using sysvinit.

I also remount the filesystem readonly before boot, to let debian run the e2fsck.

